### PR TITLE
Add three.js demo with controls and GUI

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,11 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Three.js Viewer</title>
+    <title>Three.js Scene</title>
   </head>
   <body>
-    <input type="file" id="fileInput" accept=".glb,.gltf" />
-    <div id="viewer" style="width: 100%; height: calc(100vh - 40px);"></div>
+    <div id="viewer"></div>
     <script type="module" src="/src/main.js"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "threeviewer",
       "version": "0.0.0",
       "dependencies": {
+        "lil-gui": "^0.19.2",
         "three": "^0.166.0"
       },
       "devDependencies": {
@@ -796,6 +797,12 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/lil-gui": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/lil-gui/-/lil-gui-0.19.2.tgz",
+      "integrity": "sha512-nU8j4ND702ouGfQZoaTN4dfXxacvGOAVK0DtmZBVcUYUAeYQXLQAjAN50igMHiba3T5jZyKEjXZU+Ntm1Qs6ZQ==",
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "vite": "^6.3.5"
   },
   "dependencies": {
+    "lil-gui": "^0.19.2",
     "three": "^0.166.0"
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
-import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { GUI } from 'lil-gui';
 import './style.css';
 
 const viewer = document.getElementById('viewer');
@@ -9,30 +9,28 @@ renderer.setSize(viewer.clientWidth, viewer.clientHeight);
 viewer.appendChild(renderer.domElement);
 
 const scene = new THREE.Scene();
-scene.background = new THREE.Color(0x222222);
+scene.background = new THREE.Color(0x202025);
 
-const camera = new THREE.PerspectiveCamera(60, viewer.clientWidth / viewer.clientHeight, 0.1, 1000);
-camera.position.set(2, 2, 2);
+const camera = new THREE.PerspectiveCamera(60, viewer.clientWidth / viewer.clientHeight, 0.1, 100);
+camera.position.set(3, 3, 3);
 
 const controls = new OrbitControls(camera, renderer.domElement);
-controls.update();
+controls.enableDamping = true;
 
-const light = new THREE.HemisphereLight(0xffffff, 0x444444, 1.2);
-scene.add(light);
+const geometry = new THREE.TorusKnotGeometry(1, 0.3, 128, 32);
+const material = new THREE.MeshStandardMaterial({ color: 0x0077ff });
+const knot = new THREE.Mesh(geometry, material);
+scene.add(knot);
 
-function loadModel(url) {
-  const loader = new GLTFLoader();
-  loader.load(url, (gltf) => {
-    scene.add(gltf.scene);
-  });
-}
+const dirLight = new THREE.DirectionalLight(0xffffff, 1);
+dirLight.position.set(5, 5, 5);
+scene.add(dirLight);
+scene.add(new THREE.AmbientLight(0xffffff, 0.5));
 
-document.getElementById('fileInput').addEventListener('change', (e) => {
-  const file = e.target.files[0];
-  if (!file) return;
-  const url = URL.createObjectURL(file);
-  loadModel(url);
-});
+const gui = new GUI();
+const params = { speed: 0.01, color: material.color.getHex() };
+gui.addColor(params, 'color').onChange((v) => material.color.setHex(v));
+gui.add(params, 'speed', 0, 0.1, 0.001);
 
 window.addEventListener('resize', onWindowResize);
 function onWindowResize() {
@@ -44,8 +42,11 @@ function onWindowResize() {
 }
 
 onWindowResize();
+
 function animate() {
   requestAnimationFrame(animate);
+  knot.rotation.x += params.speed;
+  knot.rotation.y += params.speed;
   controls.update();
   renderer.render(scene, camera);
 }

--- a/src/style.css
+++ b/src/style.css
@@ -6,5 +6,5 @@ body {
 
 #viewer {
   width: 100%;
-  height: calc(100vh - 40px);
+  height: 100vh;
 }


### PR DESCRIPTION
## Summary
- Replace placeholder viewer with a Vite-based three.js scene.
- Add rotating torus knot, orbit camera controls, and lil-gui UI for color and speed.
- Update styling and index markup for full-screen rendering.

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689519e5edd8832db3823ee652b9be30